### PR TITLE
add: Address Check level

### DIFF
--- a/src/lib/content/flownaut/address-check/en/contracts/Password.cdc
+++ b/src/lib/content/flownaut/address-check/en/contracts/Password.cdc
@@ -1,0 +1,42 @@
+pub contract Password {
+    access(contract) let password: String
+    pub var locked: Bool
+    pub let identityStoragePath: StoragePath
+
+   pub fun unlock(guess: String) {
+      if guess == self.password {
+         self.locked = false
+      }
+   }
+
+   pub resource Identity {
+      pub fun getPassword(): String {
+         pre {
+            self.owner!.address == Password.account.address: "You are not authorized to access this password."
+         }
+         return Password.password
+      }
+   }
+
+   pub fun createIdentity(): @Identity {
+      return <-create Identity()
+   }
+
+   pub fun generatePassword(): String {
+      let passwordLength = 7
+      var words: [UInt8] = []
+      var count = 0
+      while count < passwordLength {
+         words.append(UInt8(unsafeRandom() % 26) + 65)
+         count = count + 1
+      }
+      return String.fromUTF8(words)!
+   }
+
+   init() {
+      self.identityStoragePath = /storage/IdentityStorage
+      self.account.save(<-Password.createIdentity(), to: self.identityStoragePath)
+      self.password = Password.generatePassword()
+      self.locked = true
+   }
+}

--- a/src/lib/content/flownaut/address-check/en/contracts/Password.cdc
+++ b/src/lib/content/flownaut/address-check/en/contracts/Password.cdc
@@ -27,7 +27,7 @@ pub contract Password {
       var words: [UInt8] = []
       var count = 0
       while count < passwordLength {
-         words.append(UInt8(unsafeRandom() % 26) + 65)
+         words.append(UInt8(revertibleRandom() % 26) + 65)
          count = count + 1
       }
       return String.fromUTF8(words)!

--- a/src/lib/content/flownaut/address-check/en/overview.ts
+++ b/src/lib/content/flownaut/address-check/en/overview.ts
@@ -1,0 +1,13 @@
+import { DifficultyEnum, type Flownaut } from '$lib/types/content/flownaut.interface';
+
+export const overview: Flownaut = {
+	title: 'Address Check',
+	author: {
+		name: 'Jonosuke',
+		socialMediaUrl: 'https://twitter.com/jonosuke2023',
+		avatarUrl: 'https://avatars.githubusercontent.com/u/14267423',
+		isVerified: true
+	},
+	description: `Input the correct password.`,
+	difficulty: DifficultyEnum.Novice
+};

--- a/src/lib/content/flownaut/address-check/en/readme.md
+++ b/src/lib/content/flownaut/address-check/en/readme.md
@@ -1,0 +1,46 @@
+You must guess the password of this contract to unlock superpowers.
+
+```cadence
+pub contract Password {
+    access(contract) let password: String
+    pub var locked: Bool
+    pub let identityStoragePath: StoragePath
+
+   pub fun unlock(guess: String) {
+      if guess == self.password {
+         self.locked = false
+      }
+   }
+
+   pub resource Identity {
+      pub fun getPassword(): String {
+         pre {
+            self.owner!.address == Password.account.address: "You are not authorized to access this password."
+         }
+         return Password.password
+      }
+   }
+
+   pub fun createIdentity(): @Identity {
+      return <-create Identity()
+   }
+
+   pub fun generatePassword(): String {
+      let passwordLength = 7
+      var words: [UInt8] = []
+      var count = 0
+      while count < passwordLength {
+         words.append(UInt8(unsafeRandom() % 26) + 65)
+         count = count + 1
+      }
+      return String.fromUTF8(words)!
+   }
+
+   init() {
+      self.identityStoragePath = /storage/IdentityStorage
+      self.account.save(<-Password.createIdentity(), to: self.identityStoragePath)
+      self.password = Password.generatePassword()
+      self.locked = true
+   }
+}
+```

--- a/src/lib/content/flownaut/address-check/en/success.cdc
+++ b/src/lib/content/flownaut/address-check/en/success.cdc
@@ -1,0 +1,5 @@
+import Password from "./contracts/Password.cdc"
+
+pub fun main(user: Address): Bool {
+    return !Password.locked
+}


### PR DESCRIPTION
### Step 1
Get password.
```
import Password from contract address

pub fun main(): String {
    let account = getAuthAccount(contract address)
    let ref = account.borrow<&Password.Identity>(from: Password.identityStoragePath)!
    return ref.getPassword()
}
```

### Step2
Unlock.
```
import Password from contract address

transaction {
    execute {
        Password.unlock(guess: "Password obtained in Step 1")
    }
}
```
```